### PR TITLE
Update deploy.py to fix the error "web3.exceptions.ExtraDataLengthError: The field extraData is 97 bytes, but should be 32. It is quite likely that you are connected to a POA chain"

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -53,11 +53,14 @@ abi = json.loads(
 #
 # For connecting to ganache
 w3 = Web3(Web3.HTTPProvider("http://0.0.0.0:8545"))
-w3.middleware_onion.inject(geth_poa_middleware, layer=0)
+chain_id = 1337
+
+if chain_id == 4:
+    w3.middleware_onion.inject(geth_poa_middleware, layer=0)
+    print(w3.clientVersion)
 #Added print statement to ensure connection suceeded as per
 #https://web3py.readthedocs.io/en/stable/middleware.html#geth-style-proof-of-authority
-print(w3.clientVersion)
-chain_id = 1337
+
 my_address = "0x6aABE487828603b6f0a3E1C7DAcF7F42bA42A9B2"
 private_key = "8a63f5a3608d032ba652a323d62f333f71a895d253d6aa9f5defc16a43e4d7f1"
 

--- a/deploy.py
+++ b/deploy.py
@@ -7,6 +7,7 @@ from web3 import Web3
 from solcx import compile_standard, install_solc
 import os
 from dotenv import load_dotenv
+from web3.middleware import geth_poa_middleware
 
 load_dotenv()
 
@@ -52,6 +53,10 @@ abi = json.loads(
 #
 # For connecting to ganache
 w3 = Web3(Web3.HTTPProvider("http://0.0.0.0:8545"))
+w3.middleware_onion.inject(geth_poa_middleware, layer=0)
+#Added print statement to ensure connection suceeded as per
+#https://web3py.readthedocs.io/en/stable/middleware.html#geth-style-proof-of-authority
+print(w3.clientVersion)
 chain_id = 1337
 my_address = "0x6aABE487828603b6f0a3E1C7DAcF7F42bA42A9B2"
 private_key = "8a63f5a3608d032ba652a323d62f333f71a895d253d6aa9f5defc16a43e4d7f1"


### PR DESCRIPTION
Added middleware injection incase you are getting an error when deploying to rinkbey. Error stack looks like the below

web3.exceptions.ExtraDataLengthError: The field extraData is 97 bytes, but should be 32. It is quite likely that you are connected to a POA chain. Refer to http://web3py.readthedocs.io/en/stable/middleware.html#geth-style-proof-of-authority for more details. The full extraData is: HexBytes('0xd683010a17846765746886676f312e3139856c696e7578000000000000000000435ab9eabfd7f6221c7bb33f4aa50f62b888d258f065ed49838b62b3562ad73833fa038ee6b983428def93a184d61662e4debb02de16a8075f1ea4479bbfdf9e00')